### PR TITLE
Implement Dash CAN Controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ sim-data/.vscode/settings.json
 
 # Misc
 *.DS_Store
+*.vscode

--- a/dash/dash-can/can-controller/can-controller.ino
+++ b/dash/dash-can/can-controller/can-controller.ino
@@ -12,14 +12,13 @@ void setup() {
 //  }
 //  Serial.println("CAN Bus Initialized!")
 Serial.begin(115200);
-Serial.write(5);
-Serial.write('\n');
-Serial.write(5);
-Serial.write('\n');
 }
 
 void loop() {
-
+    for (unsigned char i = 0; i < 200; i++) {
+        Serial.write(i);
+        delay(250);
+    }
 //   unsigned char len = 0;
 //   unsigned char buf[8];
 //   if (CAN_MSGAVAIL == CAN.checkReceive()) {

--- a/dash/dash-can/can-controller/can-controller.ino
+++ b/dash/dash-can/can-controller/can-controller.ino
@@ -1,0 +1,39 @@
+#include "mcp_can.h"
+
+#define SPI_CS_PIN 9
+
+MCP_CAN CAN(SPI_CS_PIN);
+
+void setup() {
+//  while (CAN.begin(CAN_250KBPS) != CAN_OK) {
+//    Serial.println("CAN BUS init failure");
+//    Serial.println("Trying again");
+//    delay(100);
+//  }
+//  Serial.println("CAN Bus Initialized!")
+Serial.begin(115200);
+Serial.write(5);
+Serial.write('\n');
+Serial.write(5);
+Serial.write('\n');
+}
+
+void loop() {
+
+//   unsigned char len = 0;
+//   unsigned char buf[8];
+//   if (CAN_MSGAVAIL == CAN.checkReceive()) {
+//     CAN.readMsgBuf(&len, buf);
+//     unsigned long id = CAN.getCanId();
+//     Serial.print("Getting Data from ID: ");
+//     Serial.println(id, HEX);
+
+//     for (int i = 0; i < len; i++) {
+//       Serial.print(buf[i]);
+//       Serial.print("\t");
+//     }
+//     Serial.println();
+//   }  
+  
+  // new line character will terminate messages
+}

--- a/dash/dash-can/screen-basic/screen-basic.ino
+++ b/dash/dash-can/screen-basic/screen-basic.ino
@@ -1,0 +1,56 @@
+#define CS_PIN 10
+#include <EEPROM.h>
+#include <SPI.h>
+#include <GD23Z.h>
+
+// CAN
+#include "mcp_can.h"
+
+#define SPI_CS_PIN 9
+
+MCP_CAN CAN(SPI_CS_PIN);
+
+// UART Config
+#define USerial Serial1
+
+unsigned long startMillis;  //some global variables available anywhere in the program
+unsigned long currentMillis;
+
+char buf[2];
+int rpm;
+int gear;
+int lastGear = 0;
+float tps;
+
+const byte numChars = 32;
+char receivedChars[numChars];
+char tempChars[numChars];
+boolean newData = false; 
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(115200);
+  USerial.begin(115200);
+  
+  GD.begin(CS_PIN);
+  startMillis = millis();  //initial start time
+}
+
+void loop() {
+  unsigned char buf = 0;
+  if (USerial.available() > 0) {
+    buf = USerial.read();
+    Serial.println(buf);
+  }
+  GD.ClearColorRGB(0,0,0);
+  GD.Clear();
+  GD.cmd_gauge(150, 136, 100, OPT_NOPOINTER, 8, 5, 0, 7500);
+  GD.ColorRGB(255,0,0);
+  GD.cmd_gauge(150, 136, 100, OPT_NOBACK | OPT_NOTICKS, 14, 5, rpm, 7500);
+  GD.ColorRGB(255,255,255);
+//  GD.cmd_text(25, 25, 25, 0, receivedChars);
+  GD.cmd_text(130, 240, 24, 0, "RPM");
+  GD.cmd_number(150, 180, 24, OPT_CENTER, rpm);
+  GD.cmd_number(350, 136, 31, OPT_CENTER, gear);
+  GD.swap();
+}

--- a/dash/dash-can/screen-basic/screen-basic.ino
+++ b/dash/dash-can/screen-basic/screen-basic.ino
@@ -41,6 +41,7 @@ void loop() {
   if (USerial.available() > 0) {
     buf = USerial.read();
     Serial.println(buf);
+    rpm = buf;
   }
   GD.ClearColorRGB(0,0,0);
   GD.Clear();


### PR DESCRIPTION
Due to issues getting CAN peripherals to cooperate with the dash screen on the same SPI bus, a dedicated CAN MCU will be used to handle sending and receiving CAN messages bound for the dash screen. To avoid the SPI issue, the messages are transmitted from the CAN MCU to the Teensy 3.2, which will be our display driver via UART (i.e Serial.write and Serial.read). 